### PR TITLE
badhorse command doesn't care about case anymore

### DIFF
--- a/lib/commands/badhorse.js
+++ b/lib/commands/badhorse.js
@@ -37,7 +37,7 @@ Signed, *Bad Horse*
 module.exports = {
   register: ()=>{
     bus.subscribe('message.direct', (eName, message) => {
-        if (message.contents === 'badhorse') message.respond(badhorseLyrics);
+        if (message.contents.toLowerCase() === 'badhorse') message.respond(badhorseLyrics);
     });
   }
 }


### PR DESCRIPTION
Tested, works as expected for me.

`@iris badhorse`
`@iris Badhorse`
`@iris BADhoRse`